### PR TITLE
Feat/cloud 46/pre commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,49 @@
+repos:
+  # Basic Hygiene 
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev:  v4.6.0                       
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml
+      - id: check-json
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  #  Terraform (fmt/validate + optional tflint) 
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.90.0
+    hooks:
+      - id: terraform_fmt
+        args: [--recursive] # Recursively checks all files in the directory
+        files: ^terraform/ # Only checks terraform files
+      - id: terraform_validate # Removes ANSI colors
+        args: [--no-color]
+        files: ^terraform/
+      
+      - id: terraform_tflint
+        args: [--args=--disable-rule=terraform_comment_syntax]
+        files: ^terraform/
+
+  #  Semgrep (SAST) 
+  - repo: https://github.com/returntocorp/semgrep
+    rev: v1.92.0
+    hooks:
+      - id: semgrep
+        args: [--config, p/ci, --error, --timeout, "120"] # Runs default configuration and blocks commit if failed. timesout after 120s
+        pass_filenames: true          # scan only staged files
+
+  #  Gitleaks (secrets) 
+  - repo: https://github.com/zricethezav/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks
+        args: [detect, --no-git, --redact]
+        pass_filenames: false         # scan the working tree 
+
+  #  Checkov (Terraform security) 
+  - repo: https://github.com/bridgecrewio/checkov
+    rev: 3.2.257
+    hooks:
+      - id: checkov
+        args: [-d, terraform, --quiet]
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,8 +33,8 @@ repos:
         pass_filenames: true          # scan only staged files
 
   #  Gitleaks (secrets) 
-  - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.30.0
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.4
     hooks:
       - id: gitleaks
         args: [detect, --no-git, --redact]

--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -1,0 +1,57 @@
+repos: 
+# Basic Hygiene
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: main
+    hooks:
+      - id: check-merge-conflict 
+      - id: check-yaml
+      - id: check-json
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+# Terraform specific
+  - repo: https://github.com/antonbabenko/pre-commit-terraform.git
+    rev: v1.90.0
+    hooks:
+      - id: terraform_fmt
+        args: [--recursive] # Recursively checks all files in the directory
+        files: ^terraform/.*\.tf$ 
+      - id: terraform_validate # Removes ANSI colors, 
+        args: [--no-color]
+        files: ^terraform/
+
+
+# TFLint
+  - repo: https://github.com/antonbabenko/pre-commit-terraform.git
+    rev: v1.90.0
+    hooks:
+        - id: terraform_tflint
+          args: [--args=--disable-rule=terraform_comment_syntax] # disabled comment syntax rule for ('#', '-')
+          files: ^terraform/
+
+# Semgrep
+  - repo: https://github.com/semgrep/semgrep.git
+    rev: v1.92.0
+    hooks:
+      - id: semgrep
+        args: [--config, p/ci, --error] # Runs default configuration and blocks commit if failed.
+        all_files: false # Only checks staged files
+
+# Gitleaks
+  - repo: https://github.com/zricethezav/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks
+        args: [detect, --no-git, --redact] # Scan the working tree, redact secrets in output
+        pass_filenames: false # Only checks staged files
+        files: ^terraform/ # Only checks terraform files
+        stages: [commit] # Runs gitleaks on commit stage
+        
+# Checkov
+  - repo: https://github.com/bridgecrewio/checkov
+    rev:  3.2.257
+    hooks:
+      - id: checkov
+        args: [--no-color, quite] # Removes ANSI colors 
+        files: ^terraform/
+      

--- a/.semgrep.yaml
+++ b/.semgrep.yaml
@@ -38,14 +38,13 @@ repos:
         all_files: false # Only checks staged files
 
 # Gitleaks
-  - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.30.0
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.4
     hooks:
       - id: gitleaks
         args: [detect, --no-git, --redact] # Scan the working tree, redact secrets in output
         pass_filenames: false # Only checks staged files
-        files: ^terraform/ # Only checks terraform files
-        stages: [commit] # Runs gitleaks on commit stage
+      
         
 # Checkov
   - repo: https://github.com/bridgecrewio/checkov


### PR DESCRIPTION
chore(pre-commit): fix gitleaks hook repo and tag CLOUD-46

- updated repo URL from zricethezav/gitleaks → gitleaks/gitleaks
- corrected rev to v8.18.4 (valid release tag)
- ensured hook runs with detect, --no-git, and --redact args
ref: CLOUD-46