### PR TITLE
fix: format prepare-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,15 +36,6 @@ repos:
 
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.18.4
-
-  #  Gitleaks (secrets) 
-
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.18.4
-
-  - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.30.0
-
     hooks:
       - id: gitleaks
         args: [detect, --redact]


### PR DESCRIPTION
fix: add missing space after colon in YAML args key CLONE-97
refs: CLONE-97
