### PR TITLE
Feat/cloud 37/add gha security scans

### DIFF
--- a/.github/workflows/security_scans.yml
+++ b/.github/workflows/security_scans.yml
@@ -1,0 +1,43 @@
+name: Security Scans
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+permissions:
+    contents: read
+jobs:
+ semgrep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Semgrep
+        run: semgrep --config .semgrep.yml --error --json > semgrep-report.json
+      - name: Upload Semgrep Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: semgrep-report
+          path: semgrep-report.json
+
+ gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Gitleaks
+        run: gitleaks detect --source . --report-format json --report-path gitleaks-report.json
+      - name: Upload Gitleaks Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-report
+          path: gitleaks-report.json
+ checkov:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Checkov
+        run: checkov --directory terraform --output json > checkov-report.json
+      - name: Upload Checkov Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkov-report
+          path: checkov-report.json

--- a/.github/workflows/security_scans.yml
+++ b/.github/workflows/security_scans.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Gitleaks
         run: |
-          wget -O gitleaks.tar.gz https://github.com/gitleaks/gitleaks/releases/download/v8.18.4/gitleaks-linux-amd64.tar.gz
+          wget -O gitleaks.tar.gz https://github.com/gitleaks/gitleaks/releases/download/v8.28.0/gitleaks-linux-amd64.tar.gz
           sudo mv gitleaks /usr/local/bin/gitleaks
       - name: Run Gitleaks
         run: gitleaks detect --source . --report-format json --report-path gitleaks-report.json

--- a/.github/workflows/security_scans.yml
+++ b/.github/workflows/security_scans.yml
@@ -27,8 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Gitleaks
         run: |
-          wget -O gitleaks.tar.gz https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks-linux-amd64.tar.gz
-          tar -xvf gitleaks.tar.gz
+          wget -O gitleaks.tar.gz https://github.com/gitleaks/gitleaks/releases/download/v8.18.4/gitleaks-linux-amd64.tar.gz
           sudo mv gitleaks /usr/local/bin/gitleaks
       - name: Run Gitleaks
         run: gitleaks detect --source . --report-format json --report-path gitleaks-report.json

--- a/.github/workflows/security_scans.yml
+++ b/.github/workflows/security_scans.yml
@@ -25,6 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Gitleaks
+        run: |
+          wget -O gitleaks.tar.gz https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks-linux-amd64.tar.gz
+          tar -xvf gitleaks.tar.gz
+          sudo mv gitleaks /usr/local/bin/gitleaks
       - name: Run Gitleaks
         run: gitleaks detect --source . --report-format json --report-path gitleaks-report.json
       - name: Upload Gitleaks Report
@@ -36,6 +41,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Checkov
+        run: pip install checkov
       - name: Run Checkov
         run: checkov --directory terraform --output json > checkov-report.json
       - name: Upload Checkov Report

--- a/.github/workflows/security_scans.yml
+++ b/.github/workflows/security_scans.yml
@@ -25,6 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Gitleaks
+        run: |
+          wget -O gitleaks.tar.gz https://github.com/gitleaks/gitleaks/releases/download/v8.18.4/gitleaks-linux-amd64.tar.gz
+          sudo mv gitleaks /usr/local/bin/gitleaks
       - name: Run Gitleaks
         run: gitleaks detect --source . --report-format json --report-path gitleaks-report.json
       - name: Upload Gitleaks Report
@@ -36,6 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Checkov
+        run: pip install checkov
       - name: Install Checkov
         run: pip install checkov
       - name: Run Checkov

--- a/.github/workflows/security_scans.yml
+++ b/.github/workflows/security_scans.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Semgrep
+        run: pip install semgrep
       - name: Run Semgrep
         run: semgrep --config .semgrep.yml --error --json > semgrep-report.json
       - name: Upload Semgrep Report

--- a/docs/read
+++ b/docs/read
@@ -1,1 +1,0 @@
-hello woer

--- a/docs/read
+++ b/docs/read
@@ -1,0 +1,1 @@
+hello woer


### PR DESCRIPTION
fix(CLOUD-37): pin Gitleaks install to stable version in security_scans workflow

- Uses v8.28.0for reliable Gitleaks installation
- Prevents 404 errors from missing or unpublished latest releases